### PR TITLE
Use decimals instead of integers for percentages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ const countSumOfMessages = (data: Array<AggregatedData>) => {
 };
 
 const calcRatioPercentage = (count: number, sum: number) => {
-  const result = Math.floor(count / sum * 100);
+  const result = (count / sum * 100).toFixed(1);
   return `${result}%`;
 };
 


### PR DESCRIPTION
Use `toFixed(1)` instead of `Math.floor()`to calculate percentages.

<img width="418" alt="Screen Shot 2021-06-02 at 11 29 03" src="https://user-images.githubusercontent.com/18009/120414979-c48c3b00-c395-11eb-979f-2f93e16a0280.png">
